### PR TITLE
Detect inherited private properties

### DIFF
--- a/src/Reflect/Exception/UnreflectableException.php
+++ b/src/Reflect/Exception/UnreflectableException.php
@@ -35,6 +35,15 @@ final class UnreflectableException extends RuntimeException
         );
     }
 
+    public static function unreadableProperty(string $className, string $property, ?Throwable $previous = null): self
+    {
+        return new self(
+            sprintf('Unable to read property %s::$%s.', $className, $property),
+            0,
+            $previous
+        );
+    }
+
     public static function nonInstantiatable(string $className, Throwable $previous): self
     {
         return new self(

--- a/src/Reflect/property_get.php
+++ b/src/Reflect/property_get.php
@@ -3,6 +3,7 @@
 namespace VeeWee\Reflecta\Reflect;
 
 use ReflectionProperty;
+use Throwable;
 use VeeWee\Reflecta\Reflect\Exception\UnreflectableException;
 use VeeWee\Reflecta\Reflect\Type\ReflectedClass;
 
@@ -11,9 +12,14 @@ use VeeWee\Reflecta\Reflect\Type\ReflectedClass;
  */
 function property_get(object $object, string $name): mixed
 {
-    $property = ReflectedClass::fromObject($object)->property($name);
+    $class = ReflectedClass::fromObject($object);
+    $property = $class->property($name);
 
-    return $property->apply(
-        static fn (ReflectionProperty $property): mixed => $property->getValue($object)
-    );
+    try {
+        return $property->apply(
+            static fn (ReflectionProperty $reflectionProperty): mixed => $reflectionProperty->getValue($object)
+        );
+    } catch (Throwable $previous) {
+        throw UnreflectableException::unreadableProperty($class->fullName(), $name, $previous);
+    }
 }

--- a/tests/fixtures/AbstractProperties.php
+++ b/tests/fixtures/AbstractProperties.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace VeeWee\Reflecta\TestFixtures;
+
+abstract class AbstractProperties
+{
+    private string $a = 'a';
+    protected string $b = 'b';
+    public string $c = 'c';
+}

--- a/tests/unit/Iso/ObjectDataTest.php
+++ b/tests/unit/Iso/ObjectDataTest.php
@@ -5,6 +5,7 @@ namespace VeeWee\Reflecta\UnitTests\Iso;
 
 use PHPUnit\Framework\TestCase;
 use VeeWee\Reflecta\Reflect\Type\Visibility;
+use VeeWee\Reflecta\TestFixtures\AbstractProperties;
 use VeeWee\Reflecta\TestFixtures\X;
 use function VeeWee\Reflecta\Iso\object_data;
 use function VeeWee\Reflecta\Lens\properties;
@@ -50,5 +51,31 @@ final class ObjectDataTest extends TestCase
         $actualSkippedPrivate = $iso->from(['z' => 300, 'y' => 5000]);
         $expectedInstance->z = 300;
         static::assertEquals($expectedInstance, $actualSkippedPrivate);
+    }
+
+    public function test_it_can_hydrate_inherited_private_props(): void
+    {
+        $x = new class extends AbstractProperties {
+            private string $d = 'd';
+            protected string $e = 'e';
+            public string $f = 'f';
+        };
+        $iso = object_data($x::class);
+
+        $expectedData = [
+            'a' => 'a',
+            'b' => 'b',
+            'c' => 'c',
+            'd' => 'd',
+            'e' => 'e',
+            'f' => 'f',
+        ];
+        $expectedInstance = $x;
+
+        $instance = $iso->from($expectedData);
+        $actualData = $iso->to($instance);
+
+        static::assertEquals($expectedInstance, $instance);
+        static::assertSame($expectedData, $actualData);
     }
 }

--- a/tests/unit/Reflect/Exception/UnreflectableExceptionTest.php
+++ b/tests/unit/Reflect/Exception/UnreflectableExceptionTest.php
@@ -10,7 +10,7 @@ use VeeWee\Reflecta\Reflect\Exception\UnreflectableException;
 
 final class UnreflectableExceptionTest extends TestCase
 {
-    
+
     public function test_it_can_throw_unkown_property(): void
     {
         $previous = new Exception('hey');
@@ -25,7 +25,7 @@ final class UnreflectableExceptionTest extends TestCase
         throw $exception;
     }
 
-    
+
     public function test_it_can_throw_non_instantiatable_class(): void
     {
         $previous = new Exception('hey');
@@ -40,7 +40,7 @@ final class UnreflectableExceptionTest extends TestCase
         throw $exception;
     }
 
-    
+
     public function test_it_can_throw_unkown_class(): void
     {
         $previous = new Exception('hey');
@@ -55,7 +55,7 @@ final class UnreflectableExceptionTest extends TestCase
         throw $exception;
     }
 
-    
+
     public function test_it_can_throw_unwritable_property(): void
     {
         $previous = new Exception('hey');
@@ -66,6 +66,20 @@ final class UnreflectableExceptionTest extends TestCase
         $this->expectExceptionObject($exception);
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to write type string to property class::$prop.');
+
+        throw $exception;
+    }
+
+    public function test_it_can_throw_unreadable_property(): void
+    {
+        $previous = new Exception('hey');
+        $exception = UnreflectableException::unreadableProperty('class', 'prop', $previous);
+
+        static::assertSame($previous, $exception->getPrevious());
+        static::assertSame(0, $exception->getCode());
+        $this->expectExceptionObject($exception);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to read property class::$prop.');
 
         throw $exception;
     }

--- a/tests/unit/Reflect/PropertyGetTest.php
+++ b/tests/unit/Reflect/PropertyGetTest.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 namespace VeeWee\Reflecta\UnitTests\Reflect;
 
 use PHPUnit\Framework\TestCase;
+use VeeWee\Reflecta\Reflect\Exception\UnreflectableException;
 use VeeWee\Reflecta\TestFixtures\X;
 use function VeeWee\Reflecta\Reflect\property_get;
 
 final class PropertyGetTest extends TestCase
 {
-    
+
     public function test_it_can_get_property(): void
     {
         $x = new X();
@@ -18,5 +19,19 @@ final class PropertyGetTest extends TestCase
         $actual = property_get($x, 'z');
 
         static::assertSame(123, $actual);
+    }
+
+    public function test_it_can_fail_getting_property_value(): void
+    {
+        $x = new class() {
+            /**
+             * This property is not initialize yet...
+             */
+            private string $x;
+        };
+
+        $this->expectException(UnreflectableException::class);
+        $this->expectExceptionMessage('Unable to read property '.$x::class.'::$x.');
+        property_get($x, 'x');
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #5

Fixes #5

#### Summary

This change makes it possible to hydrate inherited private properties.

```php
class A {
    private string $id = 'id';
}

class B extends A {
    private string $sku = 'sku';
}
class C extends B {
    protected string $name = 'name';
}

$a = new A();
$b = new B();
$c = new C();


var_dump(object_data(C::class)->to($c));
var_dump(object_data(C::class)->from([
    'id' => 'Andre',
    'sku' => 'Bernard',
    'name' => 'Cecile',
]));
```

```
array(3) {
  'id' =>
  string(2) "id"
  'sku' =>
  string(3) "sku"
  'name' =>
  string(4) "name"
}

class C#20 (3) {
  private string $id =>
  string(5) "Andre"
  private string $sku =>
  string(7) "Bernard"
  protected string $name =>
  string(6) "Cecile"
}
```
