### PR TITLE
Set dynamic properties with predicate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,6 @@
             "./vendor/bin/infection --show-mutations -v"
         ],
         "ci": [
-            "@autoload",
             "@parallel cs psalm tests",
             "@parallel infection"
       ]

--- a/docs/reflect.md
+++ b/docs/reflect.md
@@ -191,6 +191,9 @@ try {
 }
 ```
 
+**Note:** When setting a predicate on a dynamic class, new properties will always be added.
+The next time you call `properties_get` on the same object, the predicate knows about the new property and will take it into account whilst filtering.
+
 #### property_get
 
 Detects the value of a property for a given object.

--- a/src/Reflect/properties_set.php
+++ b/src/Reflect/properties_set.php
@@ -6,7 +6,10 @@ use Closure;
 use VeeWee\Reflecta\Reflect\Exception\UnreflectableException;
 use VeeWee\Reflecta\Reflect\Type\ReflectedClass;
 use VeeWee\Reflecta\Reflect\Type\ReflectedProperty;
+use function Psl\Dict\diff_by_key;
+use function Psl\Dict\filter;
 use function Psl\Dict\intersect_by_key;
+use function Psl\Dict\merge;
 use function Psl\Iter\reduce_with_keys;
 
 /**
@@ -15,17 +18,20 @@ use function Psl\Iter\reduce_with_keys;
  * @param null|Closure(ReflectedProperty): bool $predicate
  *
  * @return T
- *@throws UnreflectableException
+ * @throws UnreflectableException
  *
  * @template T of object
- *
  */
 function properties_set(object $object, array $values, Closure|null $predicate = null): object
 {
-    $properties = ReflectedClass::fromObject($object)->properties($predicate);
+    $class = ReflectedClass::fromObject($object);
+
+    $allProperties = $class->properties();
+    $filteredProperties = $predicate ? filter($allProperties, $predicate) : $allProperties;
+    $newValues = $class->isDynamic() ? diff_by_key($values, $allProperties) : [];
 
     return reduce_with_keys(
-        intersect_by_key($values, $properties),
+        merge($newValues, intersect_by_key($values, $filteredProperties)),
         /**
          * @param T $object
          * @return T

--- a/tests/unit/Iso/ObjectDataTest.php
+++ b/tests/unit/Iso/ObjectDataTest.php
@@ -36,11 +36,10 @@ final class ObjectDataTest extends TestCase
             private int $y = 200;
         };
 
-        $iso = object_data(X::class, properties(property_visibility(Visibility::Public)));
+        $iso = object_data($x::class, properties(property_visibility(Visibility::Public)));
 
         $expectedData = ['z' => 100];
-        $expectedInstance = new X();
-        $expectedInstance->z = 100;
+        $expectedInstance = clone $x;
 
         $instance = $iso->from($expectedData);
         $actualData = $iso->to($instance);

--- a/tests/unit/Reflect/PropertiesSetTest.php
+++ b/tests/unit/Reflect/PropertiesSetTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace VeeWee\Reflecta\UnitTests\Reflect;
 
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use VeeWee\Reflecta\Reflect\Type\ReflectedProperty;
 use VeeWee\Reflecta\TestFixtures\Dynamic;
 use VeeWee\Reflecta\TestFixtures\X;
@@ -33,5 +34,38 @@ final class PropertiesSetTest extends TestCase
         static::assertInstanceOf(Dynamic::class, $actual);
         static::assertSame($actual->x, '456');
         static::assertSame($actual->y, '123');
+    }
+
+    public function test_it_can_hydrate_new_props_on_std_class(): void
+    {
+        $x = new stdClass();
+        $x->foo = 'foo';
+
+        $actual = properties_set($x, ['bar' => 'bar']);
+
+        static::assertNotSame($x, $actual);
+        static::assertInstanceOf(stdClass::class, $actual);
+        static::assertSame($actual->foo, 'foo');
+        static::assertSame($actual->bar, 'bar');
+    }
+
+    public function test_it_can_hydrate_new_props_on_std_class_with_predicate(): void
+    {
+        $x = new stdClass();
+        $x->foo = 'foo';
+
+        $actual = properties_set(
+            $x,
+            [
+                'foo' => 'baz',
+                'bar' => 'bar',
+            ],
+            static fn (ReflectedProperty $property): bool => false
+        );
+
+        static::assertNotSame($x, $actual);
+        static::assertInstanceOf(stdClass::class, $actual);
+        static::assertSame($actual->foo, 'foo');
+        static::assertSame($actual->bar, 'bar');
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/
| BC Break     | no
| Fixed issues |

#### Summary

The new predicate system in `properties_set` did not take into account new properties on dynamic classes.
This PR fixes that:

```php
$x = new \stdClass();
$x->foo = 'foo';

$actual = properties_set($x, ['bar' => 'bar']);

static::assertNotSame($x, $actual);
static::assertInstanceOf(\stdClass::class, $actual);
static::assertSame($actual->foo, 'foo');
static::assertSame($actual->bar, 'bar');
```

```php
$x = new \stdClass();
$x->foo = 'foo';

$actual = properties_set(
    $x,
    [
        'foo' => 'baz',
        'bar' => 'bar',
    ],
    static fn (ReflectedProperty $property): bool => false
);

static::assertNotSame($x, $actual);
static::assertInstanceOf(\stdClass::class, $actual);
static::assertSame($actual->foo, 'foo');
static::assertSame($actual->bar, 'bar');
```
