### PR TITLE
Let psalm known assignments of unknown properties

### DIFF
--- a/src/Psalm/Reflect/Infer/PropertyValueType.php
+++ b/src/Psalm/Reflect/Infer/PropertyValueType.php
@@ -14,6 +14,9 @@ use VeeWee\Reflecta\Reflect\Type\ReflectedClass;
 
 final class PropertyValueType
 {
+    /**
+     * @throws UnreflectableException
+     */
     public static function infer(
         TNamedObject | TTemplateParam | null $objectType,
         TLiteralString | null $propertyNameType
@@ -22,11 +25,7 @@ final class PropertyValueType
             return null;
         }
 
-        try {
-            $prop = ReflectedClass::fromFullyQualifiedClassName($objectType->value)->property($propertyNameType->value);
-        } catch (UnreflectableException $e) {
-            return null;
-        }
+        $prop = ReflectedClass::fromFullyQualifiedClassName($objectType->value)->property($propertyNameType->value);
 
         return Reflection::getPsalmTypeFromReflectionType($prop->apply(
             static fn (ReflectionProperty $reflected) => $reflected->getType()

--- a/src/Psalm/Reflect/Provider/PropertyGetProvider.php
+++ b/src/Psalm/Reflect/Provider/PropertyGetProvider.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace VeeWee\Reflecta\Psalm\Reflect\Provider;
 
+use Psalm\Issue\UndefinedPropertyFetch;
+use Psalm\IssueBuffer;
 use Psalm\Plugin\DynamicFunctionStorage;
 use Psalm\Plugin\EventHandler\DynamicFunctionStorageProviderInterface;
 use Psalm\Plugin\EventHandler\Event\DynamicFunctionStorageProviderEvent;
@@ -11,6 +13,7 @@ use Psalm\Type\Union;
 use VeeWee\Reflecta\Psalm\Reflect\Infer\ObjectType;
 use VeeWee\Reflecta\Psalm\Reflect\Infer\PropertyNameType;
 use VeeWee\Reflecta\Psalm\Reflect\Infer\PropertyValueType;
+use VeeWee\Reflecta\Reflect\Exception\UnreflectableException;
 
 final class PropertyGetProvider implements DynamicFunctionStorageProviderInterface
 {
@@ -29,7 +32,21 @@ final class PropertyGetProvider implements DynamicFunctionStorageProviderInterfa
 
         $objectType = ObjectType::infer($inferrer, $args[0]);
         $propertyNameType = PropertyNameType::infer($inferrer, $args[1]);
-        $inferredReturnType = PropertyValueType::infer($objectType, $propertyNameType);
+
+        try {
+            $inferredReturnType = PropertyValueType::infer($objectType, $propertyNameType);
+        } catch (UnreflectableException $e) {
+            IssueBuffer::maybeAdd(
+                new UndefinedPropertyFetch(
+                    $e->getMessage(),
+                    $event->getCodeLocation(),
+                    $objectType->value . '::' . $propertyNameType->value,
+                ),
+                $event->getStatementSource()->getSuppressedIssues()
+            );
+
+            return null;
+        }
 
         if (!$objectType || !$propertyNameType || !$inferredReturnType) {
             return null;

--- a/tests/static-analyzer/Reflect/property_get.php
+++ b/tests/static-analyzer/Reflect/property_get.php
@@ -23,3 +23,14 @@ function test_get_mixed_return_type_on_templated_object(): mixed
 
     return $curried($z)($x);
 }
+
+/**
+ * @psalm-suppress UndefinedPropertyFetch
+ */
+function test_getting_unknown_property(): mixed
+{
+    $unknown = 'unknown';
+    $x = new X();
+
+    return property_get($x, $unknown);
+}

--- a/tests/static-analyzer/Reflect/property_set.php
+++ b/tests/static-analyzer/Reflect/property_set.php
@@ -27,6 +27,17 @@ function test_set_invalid_prop_value_type(): X
     return property_set($x, $z, 'nope');
 }
 
+/**
+ * @psalm-suppress UndefinedPropertyAssignment
+ */
+function test_assigning_unknown_property(): X
+{
+    $unknown = 'unknown';
+    $x = new X();
+
+    return property_set($x, $unknown, 'nope');
+}
+
 function test_return_type_on_templated_object(): object
 {
     $curried = static fn (string $path): Closure => static fn (object $object, mixed $value): mixed => property_set($object, $path, $value);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues |

#### Summary

Adds `UndefinedPropertyFetch` and `UndefinedPropertyAssignment` to property_get|set methods when psalm cannot find the property on the given class.

![Screenshot 2025-01-24 at 16 10 03](https://github.com/user-attachments/assets/df95793b-bbca-46ed-aef5-7a436c93f247)

