### PR TITLE
Replace azjezz/psl with php-standard-library/php-standard-library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     ],
     "require": {
         "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-        "azjezz/psl": "~3.0 || ~4.0 || ~5.0"
+        "php-standard-library/php-standard-library": "^3.0 || ~4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "vimeo/psalm": "~6.13",


### PR DESCRIPTION
## Summary
- Replace `azjezz/psl` with `php-standard-library/php-standard-library` (the package moved to a new vendor name)
- Allow versions `^3.0 || ~4.0 || ^5.0 || ^6.0`

## Test plan
- [ ] CI passes (namespace `Psl\` is unchanged, only the composer package name changed)