### PR TITLE
Optimize properties_set to clone once instead of per property

### DIFF
--- a/src/Reflect/properties_set.php
+++ b/src/Reflect/properties_set.php
@@ -3,6 +3,9 @@
 namespace VeeWee\Reflecta\Reflect;
 
 use Closure;
+use ReflectionProperty;
+use Throwable;
+use VeeWee\Reflecta\Exception\CloneException;
 use VeeWee\Reflecta\Reflect\Exception\UnreflectableException;
 use VeeWee\Reflecta\Reflect\Type\ReflectedClass;
 use VeeWee\Reflecta\Reflect\Type\ReflectedProperty;
@@ -10,7 +13,6 @@ use function Psl\Dict\diff_by_key;
 use function Psl\Dict\filter;
 use function Psl\Dict\intersect_by_key;
 use function Psl\Dict\merge;
-use function Psl\Iter\reduce_with_keys;
 
 /**
  * @param T $object
@@ -34,13 +36,33 @@ function properties_set(object $object, array $values, Closure|null $predicate =
         $values = merge($unknownValues, intersect_by_key($values, $filteredProperties));
     }
 
-    return reduce_with_keys(
-        $values,
-        /**
-         * @param T $object
-         * @return T
-         */
-        static fn (object $object, string $name, mixed $value): object => property_set($object, $name, $value),
-        $object
-    );
+    if (!$values) {
+        return $object;
+    }
+
+    try {
+        /** @var T $new */
+        $new = clone $object;
+    } catch (Throwable $previous) {
+        throw CloneException::impossibleToClone($object, $previous);
+    }
+
+    $isDynamic = $class->isDynamic();
+
+    /** @var mixed $value */
+    foreach ($values as $name => $value) {
+        try {
+            $class->property($name)->apply(
+                static fn (ReflectionProperty $reflectionProperty) => $reflectionProperty->setValue($new, $value)
+            );
+        } catch (UnreflectableException $e) {
+            if ($isDynamic) {
+                $new->{$name} = $value;
+            } else {
+                throw $e;
+            }
+        }
+    }
+
+    return $new;
 }


### PR DESCRIPTION
## Summary

`properties_set()` previously called `property_set()` per property, which cloned the object on every call. For an object with N properties, that's N clones and N `ReflectedClass::fromObject()` lookups.

Now clones once and sets all properties on the single clone directly using `ReflectionProperty::setValue()`. Dynamic properties (`stdClass`, `AllowDynamicProperties`) are handled via direct property assignment as a fallback.

## Impact

For an object with 9 properties, `properties_set` cost drops from ~10us to ~5.5us (~45% faster). Measured in the php-soap/encoding benchmark suite where this is on the decode hot path.

## Changes

- Clone once at the start instead of per property
- Iterate values and set via `ReflectionProperty::setValue()` directly
- Handle dynamic properties inline (same behavior as `property_set`)
- Empty values short-circuit (return original object)

## Test plan

- [x] Full test suite passes (119 tests)
- [x] Psalm clean
- [x] CS fixer clean
- [x] Benchmarked in php-soap/encoding: -4% to -9% decode improvement