### PR TITLE
Fix compose() boundary detection under covariant Iso/Lens templates

### DIFF
--- a/src/Psalm/Compose/AdjacentTemplateValidator.php
+++ b/src/Psalm/Compose/AdjacentTemplateValidator.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+namespace VeeWee\Reflecta\Psalm\Compose;
+
+use Psalm\CodeLocation;
+use Psalm\Internal\Type\Comparator\UnionTypeComparator;
+use Psalm\IssueBuffer;
+use Psalm\Issue\InvalidArgument;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Union;
+
+use function count;
+use function strtolower;
+
+/**
+ * @internal
+ *
+ * Since Iso/Lens templates are covariant, Psalm's template-inference based
+ * argument check will silently widen the shared boundary type between
+ * adjacent compose() args (e.g. accepting Iso<A,B>, Iso<C,C>, Iso<C,D>).
+ *
+ * This validator walks the adjacent arg pairs and emits InvalidArgument
+ * when the right template of arg[i] is not equivalent to the left template
+ * of arg[i+1].
+ */
+final class AdjacentTemplateValidator
+{
+    /**
+     * @param class-string $genericClass Iso::class or Lens::class
+     * @param non-empty-string $functionId
+     */
+    public static function validate(
+        FunctionReturnTypeProviderEvent $event,
+        string $genericClass,
+        string $functionId,
+    ): void {
+        $args = $event->getCallArgs();
+        if (count($args) < 2) {
+            return;
+        }
+
+        $source = $event->getStatementsSource();
+        $nodeTypes = $source->getNodeTypeProvider();
+        $codebase = $source->getCodebase();
+        $suppressed = $source->getSuppressedIssues();
+
+        $genericClassLc = strtolower($genericClass);
+
+        $previousRight = null;
+        $previousIndex = 0;
+        foreach ($args as $index => $arg) {
+            $argType = $nodeTypes->getType($arg->value);
+            if ($argType === null) {
+                $previousRight = null;
+                continue;
+            }
+
+            $generic = self::extractGeneric($argType, $genericClassLc);
+            if ($generic === null) {
+                $previousRight = null;
+                continue;
+            }
+
+            [$left, $right] = $generic;
+
+            if ($previousRight !== null) {
+                $forward = UnionTypeComparator::isContainedBy($codebase, $previousRight, $left);
+                $backward = UnionTypeComparator::isContainedBy($codebase, $left, $previousRight);
+
+                if (!$forward || !$backward) {
+                    IssueBuffer::maybeAdd(
+                        new InvalidArgument(
+                            'Argument ' . ($index + 1) . ' of ' . $functionId
+                            . ' expects ' . $genericClass . '<' . $previousRight->getId() . ', ...>,'
+                            . ' ' . $genericClass . '<' . $left->getId() . ', ...> provided'
+                            . ' (compose boundary mismatch with argument ' . ($previousIndex + 1) . ')',
+                            new CodeLocation($source, $arg->value),
+                            $functionId,
+                        ),
+                        $suppressed,
+                    );
+                }
+            }
+
+            $previousRight = $right;
+            $previousIndex = $index;
+        }
+    }
+
+    /**
+     * @param lowercase-string $genericClassLc
+     * @return array{0: Union, 1: Union}|null
+     */
+    private static function extractGeneric(Union $argType, string $genericClassLc): ?array
+    {
+        foreach ($argType->getAtomicTypes() as $atomic) {
+            if (!$atomic instanceof TGenericObject) {
+                continue;
+            }
+            if (strtolower($atomic->value) !== $genericClassLc) {
+                continue;
+            }
+            if (count($atomic->type_params) < 2) {
+                continue;
+            }
+
+            return [$atomic->type_params[0], $atomic->type_params[1]];
+        }
+
+        return null;
+    }
+}

--- a/src/Psalm/Compose/AdjacentTemplateValidator.php
+++ b/src/Psalm/Compose/AdjacentTemplateValidator.php
@@ -5,8 +5,8 @@ namespace VeeWee\Reflecta\Psalm\Compose;
 
 use Psalm\CodeLocation;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
-use Psalm\IssueBuffer;
 use Psalm\Issue\InvalidArgument;
+use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Union;

--- a/src/Psalm/Iso/Provider/ComposeProvider.php
+++ b/src/Psalm/Iso/Provider/ComposeProvider.php
@@ -7,24 +7,37 @@ use Psalm\Plugin\DynamicFunctionStorage;
 use Psalm\Plugin\DynamicTemplateProvider;
 use Psalm\Plugin\EventHandler\DynamicFunctionStorageProviderInterface;
 use Psalm\Plugin\EventHandler\Event\DynamicFunctionStorageProviderEvent;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\Union;
 
 use VeeWee\Reflecta\Iso\Iso;
+use VeeWee\Reflecta\Psalm\Compose\AdjacentTemplateValidator;
 use function array_map;
 use function count;
 use function range;
 
-final class ComposeProvider implements DynamicFunctionStorageProviderInterface
+final class ComposeProvider implements DynamicFunctionStorageProviderInterface, FunctionReturnTypeProviderInterface
 {
+    private const FUNCTION_ID = 'veewee\reflecta\iso\compose';
+
     /**
      * @return array<lowercase-string>
      */
     public static function getFunctionIds(): array
     {
-        return ['veewee\reflecta\iso\compose'];
+        return [self::FUNCTION_ID];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Union
+    {
+        AdjacentTemplateValidator::validate($event, Iso::class, self::FUNCTION_ID);
+
+        // Defer return type to the DynamicFunctionStorage provider.
+        return null;
     }
 
     public static function getFunctionStorage(DynamicFunctionStorageProviderEvent $event): ?DynamicFunctionStorage

--- a/src/Psalm/Lens/Provider/ComposeProvider.php
+++ b/src/Psalm/Lens/Provider/ComposeProvider.php
@@ -7,24 +7,37 @@ use Psalm\Plugin\DynamicFunctionStorage;
 use Psalm\Plugin\DynamicTemplateProvider;
 use Psalm\Plugin\EventHandler\DynamicFunctionStorageProviderInterface;
 use Psalm\Plugin\EventHandler\Event\DynamicFunctionStorageProviderEvent;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\Union;
 
 use VeeWee\Reflecta\Lens\Lens;
+use VeeWee\Reflecta\Psalm\Compose\AdjacentTemplateValidator;
 use function array_map;
 use function count;
 use function range;
 
-final class ComposeProvider implements DynamicFunctionStorageProviderInterface
+final class ComposeProvider implements DynamicFunctionStorageProviderInterface, FunctionReturnTypeProviderInterface
 {
+    private const FUNCTION_ID = 'veewee\reflecta\lens\compose';
+
     /**
      * @return array<lowercase-string>
      */
     public static function getFunctionIds(): array
     {
-        return ['veewee\reflecta\lens\compose'];
+        return [self::FUNCTION_ID];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Union
+    {
+        AdjacentTemplateValidator::validate($event, Lens::class, self::FUNCTION_ID);
+
+        // Defer return type to the DynamicFunctionStorage provider.
+        return null;
     }
 
     public static function getFunctionStorage(DynamicFunctionStorageProviderEvent $event): ?DynamicFunctionStorage

--- a/tests/static-analyzer/Iso/compose.php
+++ b/tests/static-analyzer/Iso/compose.php
@@ -32,8 +32,7 @@ function it_knows_composed_result(Iso $iso1, Iso $iso2, Iso $iso3): Iso
  * @param Iso<C,D> $iso3
  * @return Iso<A,D>
  *
- * @  psalm-suppress InvalidArgument -
- * TODO : Invalid compose iso-param detection does not work any since contravariant templates are introduced.
+ * @psalm-suppress InvalidArgument
  */
 function it_knows_broken_composition(Iso $iso1, Iso $iso2, Iso $iso3): Iso
 {

--- a/tests/static-analyzer/Lens/compose.php
+++ b/tests/static-analyzer/Lens/compose.php
@@ -32,8 +32,7 @@ function it_knows_composed_result(Lens $lens1, Lens $lens2, Lens $lens3): Lens
  * @param Lens<C,D> $lens3
  * @return Lens<A,D>
  *
- * @  psalm-suppress InvalidArgument -
- * TODO : Invalid compose lens-param detection does not work any since contravariant templates are introduced.
+ * @psalm-suppress InvalidArgument
  */
 function it_knows_broken_composition(Lens $lens1, Lens $lens2, Lens $lens3): Lens
 {


### PR DESCRIPTION
## Summary
- Adds a `FunctionReturnTypeProvider` hook on both `Iso\Provider\ComposeProvider` and `Lens\Provider\ComposeProvider` that walks adjacent `compose()` args and emits `InvalidArgument` when arg[i]'s right template is not mutually-contained with arg[i+1]'s left template.
- Shared validator: `src/Psalm/Compose/AdjacentTemplateValidator.php`.
- Re-activates the `@psalm-suppress InvalidArgument` markers in `tests/static-analyzer/{Iso,Lens}/compose.php`.

## Why
After #9 made the `Iso`/`Lens` templates covariant, Psalm's standard template inference silently widened the shared boundary type between adjacent compose args (e.g. accepting `compose(Iso<A,B>, Iso<C,C>, Iso<C,D>)` by inferring the boundary as `B|C`), so the existing SA tests stopped catching the broken case. Covariance is intentionally kept (php-soap/encoding depends on storing `Iso<int,string>` in `array<string, Iso<mixed,string>>`).

## Test plan
- [x] `vendor/bin/psalm --no-cache` is green (compose() suppressions are now used)
- [x] Manually flipped the suppressions to confirm the validator emits `InvalidArgument` on both Iso and Lens broken cases
- [x] `vendor/bin/phpunit --no-coverage` passes

Fixes #10

## Follow-up (not in this PR)
Per discussion, a future major could port Iso/Lens to profunctor form `Iso<S,T,A,B>` with explicit per-slot variance — that would let standard inference handle compose boundary checks without this plugin hook. Tracking separately so the php-soap/encoding migration can be coordinated.